### PR TITLE
Fix compilation issues with VS2019

### DIFF
--- a/Source/MatchOneEntt/Data/ScoreEntityId.h
+++ b/Source/MatchOneEntt/Data/ScoreEntityId.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "MatchOneEntt.h"
-#include "entt.hpp"
+#include "EnttWrapper.h"
 
 struct ScoreEntityId
 {

--- a/Source/MatchOneEntt/EnttWrapper.h
+++ b/Source/MatchOneEntt/EnttWrapper.h
@@ -1,0 +1,8 @@
+#pragma once
+
+THIRD_PARTY_INCLUDES_START
+
+#include "entt.hpp"
+
+THIRD_PARTY_INCLUDES_END
+

--- a/Source/MatchOneEntt/Extension/System.h
+++ b/Source/MatchOneEntt/Extension/System.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "entt.hpp"
+#include "EnttWrapper.h"
 
 class System
 {

--- a/Source/MatchOneEntt/Logic/GameBoard/GameBoardLogic.h
+++ b/Source/MatchOneEntt/Logic/GameBoard/GameBoardLogic.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "entt.hpp"
+#include "EnttWrapper.h"
 #include "Components/GameBoardComponent.h"
 #include "Components/PositionComponent.h"
 #include "Components/AssetComponent.h"

--- a/Source/MatchOneEntt/Logic/GameState/Systems/ScoreListenerSystem.h
+++ b/Source/MatchOneEntt/Logic/GameState/Systems/ScoreListenerSystem.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Extension/System.h"
-#include "entt.hpp"
+#include "EnttWrapper.h"
 
 class ScoreListenerSystem : public System
 {

--- a/Source/MatchOneEntt/Logic/GameState/Systems/ScoreSystem.h
+++ b/Source/MatchOneEntt/Logic/GameState/Systems/ScoreSystem.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Extension/System.h"
-#include "entt.hpp"
+#include "EnttWrapper.h"
 
 class ScoreSystem : public System
 {


### PR DESCRIPTION
Compilation issues were caused by entt implicitly casting to bool in many occasions. Unreal provides an handy define to wrap external third party libraries that automatically disables some warning / errors.